### PR TITLE
Remove expired Live Show CTA from hero section

### DIFF
--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -3,14 +3,7 @@
 import ErrorBoundary from "@/components/ui/error-boundary";
 import { useInView } from "@/hooks/use-in-view";
 import { motion } from "framer-motion";
-import {
-  Calendar,
-  ChevronDown,
-  Heart,
-  MapPin,
-  Music,
-  Timer,
-} from "lucide-react";
+import { ChevronDown, Heart } from "lucide-react";
 import { Patrick_Hand } from "next/font/google";
 import Image from "next/image";
 import React, { useEffect, useState } from "react";
@@ -21,37 +14,15 @@ const patrickHand = Patrick_Hand({
   subsets: ["latin"],
 });
 
-// Function to calculate days until the event
-const calculateDaysUntil = (targetDate: string) => {
-  const target = new Date(targetDate);
-  const today = new Date();
-  const diffTime = target.getTime() - today.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-  return diffDays > 0 ? diffDays : 0;
-};
-
 export default function HeroSection(): React.ReactElement {
   const { ref } = useInView({ threshold: 0.1 });
   const [loaded, setLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
-  const [daysUntil, setDaysUntil] = useState(0);
 
-  const eventDate = "Jun 14, 2025";
-  const eventTime = "7:00 PM CDT";
-  const eventVenue = "Magnolia Blues BBQ Company";
-  const eventLocation = "Brookhaven, MS";
-
+  // Trigger the entrance animation once component mounts
   useEffect(() => {
     setLoaded(true);
-    setDaysUntil(calculateDaysUntil(eventDate));
-
-    // Update countdown every day
-    const interval = setInterval(() => {
-      setDaysUntil(calculateDaysUntil(eventDate));
-    }, 86400000);
-
-    return () => clearInterval(interval);
-  }, [eventDate]);
+  }, []);
 
   if (imageError) {
     return (
@@ -76,7 +47,7 @@ export default function HeroSection(): React.ReactElement {
     <ErrorBoundary>
       <section
         ref={ref}
-        id="tour"
+        id="hero"
         className="relative flex min-h-screen items-center overflow-hidden pt-16 pb-0"
       >
         <div className="absolute inset-0 h-full w-full">
@@ -95,6 +66,7 @@ export default function HeroSection(): React.ReactElement {
           />
           <div className="absolute inset-0 bg-gradient-to-b from-black/0 to-black/75" />
         </div>
+
         <div className="relative z-10 container mx-auto px-6 md:px-12">
           <div
             className={`max-w-xl transition-all duration-1000 ${
@@ -110,105 +82,7 @@ export default function HeroSection(): React.ReactElement {
               </span>
             </h1>
 
-            {/* Tour Date CTA - New Addition */}
-            <div className="mt-6 mb-8 relative">
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: 0.3, duration: 0.5 }}
-                className="overflow-hidden rounded-xl border border-amber-500/30 bg-black/60 backdrop-blur-sm"
-              >
-                <div className="p-5">
-                  <div className="flex items-center gap-2 mb-3">
-                    <Calendar
-                      className="h-5 w-5 text-amber-300"
-                      aria-hidden="true"
-                    />
-                    <h3 className="text-lg font-bold uppercase text-amber-300">
-                      Live Show Coming Soon
-                    </h3>
-                  </div>
-
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
-                    <div className="flex items-start gap-3">
-                      <Calendar
-                        className="h-5 w-5 text-amber-200/70 mt-1"
-                        aria-hidden="true"
-                      />
-                      <div>
-                        <div className="text-sm text-zinc-400">Date & Time</div>
-                        <div className="text-white font-medium">
-                          {eventDate}
-                        </div>
-                        <div className="text-white font-medium">
-                          {eventTime}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="flex items-start gap-3">
-                      <MapPin
-                        className="h-5 w-5 text-amber-200/70 mt-1"
-                        aria-hidden="true"
-                      />
-                      <div>
-                        <div className="text-sm text-zinc-400">Venue</div>
-                        <div className="text-white font-medium">
-                          {eventVenue}
-                        </div>
-                        <div className="text-white font-medium">
-                          {eventLocation}
-                        </div>
-                      </div>
-                    </div>
-
-                    <div className="flex items-start gap-3">
-                      <Timer
-                        className="h-5 w-5 text-amber-200/70 mt-1"
-                        aria-hidden="true"
-                      />
-                      <div>
-                        <div className="text-sm text-zinc-400">Countdown</div>
-                        <motion.div
-                          className="text-white font-bold"
-                          initial={{ scale: 1 }}
-                          animate={{
-                            scale: [1, 1.05, 1],
-                            color: [
-                              "rgb(255, 255, 255)",
-                              "rgb(251, 191, 36)",
-                              "rgb(255, 255, 255)",
-                            ],
-                          }}
-                          transition={{
-                            repeat: Infinity,
-                            repeatType: "reverse",
-                            duration: 2,
-                            ease: "easeInOut",
-                          }}
-                        >
-                          <span className="text-xl">{daysUntil}</span> Days Left
-                        </motion.div>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap gap-4 mt-5">
-                    <a
-                      href="https://www.bandsintown.com/e/106676619-noah-lynch-at-magnolia-blues-bbq-company?came_from=281&utm_medium=web&utm_source=artist_page&utm_campaign=event"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="rounded-full border-2 border-amber-500/80 bg-amber-500/20 px-6 py-3 font-medium text-amber-100 transition-all duration-300 hover:border-amber-400/90 hover:bg-amber-500/30 flex items-center gap-2"
-                      aria-label="Get tickets for Noah Lynch at Magnolia Blues BBQ Company on June 14, 2025"
-                    >
-                      <Music className="h-4 w-4" aria-hidden="true" />
-                      Get Tickets Now
-                    </a>
-                  </div>
-                </div>
-              </motion.div>
-            </div>
-
+            {/* Primary Call-to-Action Buttons */}
             <div className="mt-4 flex flex-col gap-4">
               <div className="flex flex-wrap gap-4">
                 <a
@@ -243,6 +117,8 @@ export default function HeroSection(): React.ReactElement {
                 </a>
               </div>
             </div>
+
+            {/* Social Links */}
             <div className="mt-6 flex gap-6 ">
               <a
                 href="https://instagram.com/noahlynchmusic"
@@ -284,6 +160,7 @@ export default function HeroSection(): React.ReactElement {
           </div>
         </div>
 
+        {/* Mobile scroll indicator */}
         <motion.div
           className="absolute bottom-6 left-1/2 z-10 -translate-x-1/2 sm:hidden"
           initial={{ opacity: 0 }}
@@ -311,6 +188,7 @@ export default function HeroSection(): React.ReactElement {
           </div>
         </motion.div>
 
+        {/* Hand-written quote */}
         <div className="absolute bottom-12 right-4 z-10 p-2 max-w-xs text-right hidden md:block">
           <p
             className={`${patrickHand.className} text-md text-zinc-50/100 leading-tight `}


### PR DESCRIPTION
### Summary
Removes the out-of-date “Live Show Coming Soon” card and countdown from the hero section, and renames the section id to `hero` to avoid duplicate anchors.

### Details
* Deleted the complete Tour Date CTA block.
* Removed unused helper `calculateDaysUntil`, related state, event constants, and unused icon imports.
* Updated section id from `tour` to `hero`.

This declutters the landing page now that the June 14, 2025 show has passed, and the dedicated **Tour** section already provides a placeholder ("More Shows Coming Soon!").

— Generated via AI assistant