### PR TITLE
Add Tour placeholder section between Biography and Music

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import Navbar from "@/components/layout/navbar";
 import BiographySection from "@/components/sections/biography-section";
 import HeroSection from "@/components/sections/hero";
 import MusicShowcaseSection from "@/components/sections/MusicShowcaseSection";
+import TourSection from "@/components/sections/tour-section";
 
 export default function Home() {
   return (
@@ -9,8 +10,9 @@ export default function Home() {
       <Navbar />
       <main>
         <HeroSection />
-        <MusicShowcaseSection />
         <BiographySection />
+        <TourSection />
+        <MusicShowcaseSection />
       </main>
     </div>
   );


### PR DESCRIPTION
### Summary
Adds the existing **Tour** section (with its “More Shows Coming Soon!” banner) between the Biography and Music sections on the home page.

### Changes
1. **app/page.tsx**
   * Imported `TourSection`.
   * Re-ordered components: `Hero` → `Biography` → `Tour` → `Music`.

This gives fans an immediate hint that additional live dates are on the way without cluttering the hero.

— Generated via AI assistant